### PR TITLE
Refine media handling and lint compliance

### DIFF
--- a/app/crafts/[slug]/page.tsx
+++ b/app/crafts/[slug]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { notFound } from "next/navigation";
 import { use, useState } from "react";
 import { SEED } from "@/data/crafts.seed";
@@ -28,8 +29,8 @@ export default function CraftPage({ params }: { params: Promise<{ slug: string }
 
       <div>
         <h1 className="text-2xl font-bold mb-3">{title}</h1>
-        <div className="w-full h-44 mb-3 rounded-lg overflow-hidden">
-          <img src={hero} alt={title} className="w-full h-full object-cover" />
+        <div className="relative w-full h-44 mb-3 rounded-lg overflow-hidden">
+          <Image src={hero} alt={title} fill className="object-cover" sizes="(min-width: 768px) 320px, 100vw" />
         </div>
         <p className="text-sm leading-relaxed text-neutral-700">{String(pickLang(item.summary, "ja"))}</p>
       </div>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -24,11 +25,13 @@ export default function HomePage() {
           <CardTitle className="text-lg">本日の職人実演</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <div className="w-full h-40 rounded-lg overflow-hidden">
-            <img
+          <div className="relative w-full h-40 rounded-lg overflow-hidden">
+            <Image
               src="/images/candle-making-demo.png"
               alt="和蝋燭作りの職人実演"
-              className="w-full h-full object-cover"
+              fill
+              className="object-cover"
+              sizes="(min-width: 768px) 320px, 100vw"
             />
           </div>
           <Button variant="outline" onClick={() => setDemoOpen(true)}>
@@ -42,11 +45,13 @@ export default function HomePage() {
           <CardTitle className="text-lg">本日開催中のイベント</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="w-full h-48 rounded-lg overflow-hidden">
-            <img
+          <div className="relative w-full h-48 rounded-lg overflow-hidden">
+            <Image
               src="/images/tradition-meets-today.png"
               alt="Tradition Meets Today イベント"
-              className="w-full h-full object-cover bg-white"
+              fill
+              className="object-cover bg-white"
+              sizes="(min-width: 768px) 320px, 100vw"
             />
           </div>
           <div className="mt-3">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { ReactNode } from "react";
 import "./globals.css";
 
@@ -9,8 +10,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="min-h-screen bg-[#eeeeee] font-sans">
         <header className="fixed top-0 left-0 right-0 z-50 bg-[#eeeeee]/95 backdrop-blur-md border-b border-neutral-200">
           <div className="max-w-sm mx-auto flex items-center gap-3 px-4 py-3 min-h-[68px]">
-            <div className="w-12 h-8 flex items-center justify-center">
-              <img src="/images/museum-logo.png" alt="京都伝統産業ミュージアム ロゴ" className="h-6 w-auto object-contain" />
+            <div className="relative w-12 h-8 flex items-center justify-center">
+              <Image
+                src="/images/museum-logo.png"
+                alt="京都伝統産業ミュージアム ロゴ"
+                fill
+                className="object-contain"
+                sizes="48px"
+              />
             </div>
             <div className="flex-1">
               <div className="font-bold text-sm leading-tight tracking-wide">京都伝統産業ミュージアム</div>

--- a/components/CraftGrid.tsx
+++ b/components/CraftGrid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import type { CraftItem, Lang } from "@/types/craft";
 import { SEED } from "@/data/crafts.seed";
@@ -27,8 +28,14 @@ export default function CraftGrid({ lang = "ja" }: Props) {
             onClick={() => router.push(`/crafts/${item.slug}`)}
             className="bg-neutral-50 border border-neutral-200 rounded-lg p-2.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:ring-offset-2 transition-colors"
           >
-            <div className="w-full h-19 mb-2 rounded overflow-hidden">
-              <img src={item.imageUrl} alt={item.name} className="w-full h-full object-cover" />
+            <div className="relative w-full h-19 mb-2 rounded overflow-hidden">
+              <Image
+                src={item.imageUrl}
+                alt={item.name}
+                fill
+                className="object-cover"
+                sizes="(min-width: 768px) 200px, 33vw"
+              />
             </div>
             <div className="text-center">
               <div className="font-semibold text-sm">{item.name}</div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -33,8 +33,9 @@ export const Button: ButtonComponent = React.forwardRef<ButtonRef, ButtonProps>(
     const classes = cn(base, variants[variant], sizes[size], className);
 
     if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(children as React.ReactElement<any>, {
-        className: cn(classes, (children as React.ReactElement<any>).props?.className),
+      const child = children as React.ReactElement<{ className?: string }>;
+      return React.cloneElement(child, {
+        className: cn(classes, child.props?.className),
         ...props
       });
     }

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -127,6 +127,7 @@ export function SelectItem({ value: itemValue, children, className, ...props }: 
     <button
       role="option"
       type="button"
+      aria-selected={ctx.value === itemValue}
       onClick={() => ctx.setValue(itemValue)}
       className={cn(
         "w-full rounded-md px-2 py-1.5 text-left text-sm hover:bg-neutral-100",

--- a/lib/supabasePublic.ts
+++ b/lib/supabasePublic.ts
@@ -1,3 +1,13 @@
 export function getPublicUrl(path: string) {
-  return `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${path}`;
+  const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!baseUrl || baseUrl === "undefined" || baseUrl === "null") {
+    if (path.startsWith("http://") || path.startsWith("https://")) {
+      return path;
+    }
+    if (path.startsWith("/")) {
+      return path;
+    }
+    return "/placeholder.svg";
+  }
+  return `${baseUrl}/storage/v1/object/public/${path}`;
 }

--- a/public/placeholder.svg
+++ b/public/placeholder.svg
@@ -1,0 +1,5 @@
+<svg width="400" height="300" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder image">
+  <rect width="400" height="300" fill="#e5e7eb" />
+  <path d="M80 220l60-80 50 60 40-50 90 120H80z" fill="#d1d5db" />
+  <circle cx="140" cy="110" r="35" fill="#d1d5db" />
+</svg>

--- a/types/craft.ts
+++ b/types/craft.ts
@@ -49,11 +49,27 @@ export interface CraftItem {
 
 // ---------- 3) Helpers ----------
 export function getPublicUrl(path: string) {
-  return `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${path}`;
+  const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!baseUrl || baseUrl === "undefined" || baseUrl === "null") {
+    if (path.startsWith("http://") || path.startsWith("https://")) {
+      return path;
+    }
+    if (path.startsWith("/")) {
+      return path;
+    }
+    return "/placeholder.svg";
+  }
+  return `${baseUrl}/storage/v1/object/public/${path}`;
 }
 
-export function pickLang<T extends Record<string, any>>(ml: Partial<Record<Lang, T>>, lang: Lang): T | string {
-  return ml[lang] ?? ml.ja ?? Object.values(ml)[0] ?? '';
+export function pickLang<T>(ml: Multilang<T>, lang: Lang): T | undefined {
+  if (ml[lang] !== undefined) {
+    return ml[lang];
+  }
+  if (ml.ja !== undefined) {
+    return ml.ja;
+  }
+  return Object.values(ml).find((value): value is T => value !== undefined);
 }
 
 // ---------- 4) Example item ----------


### PR DESCRIPTION
## Summary
- replace raw image tags with Next.js Image components across craft, home, and layout views to satisfy linting and improve loading
- tighten shared utilities by hardening Supabase URL resolution, improving multilingual helpers, and providing a local placeholder asset
- address accessibility and typing lint rules in UI primitives such as Button and Select

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbba256940832ba299dbf856fa643e