### PR TITLE
Add craft grid illustrations

### DIFF
--- a/public/craft_images/bamboo.svg
+++ b/public/craft_images/bamboo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="240" viewBox="0 0 320 240">
+  <defs>
+    <linearGradient id="grad-bamboo" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fef3c7" />
+      <stop offset="100%" stop-color="#facc15" />
+    </linearGradient>
+    <pattern id="pattern-bamboo" width="24" height="24" patternUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="24" height="24" fill="#fefce8" />
+      <rect x="10" y="0" width="4" height="24" fill="#65a30d" fill-opacity="0.7" />
+      <circle cx="12" cy="6" r="3" fill="#4d7c0f" fill-opacity="0.4" />
+      <circle cx="12" cy="18" r="3" fill="#4d7c0f" fill-opacity="0.4" />
+    </pattern>
+  </defs>
+  <rect width="320" height="240" fill="url(#grad-bamboo)" />
+  <rect x="36" y="40" width="248" height="160" rx="28" fill="white" fill-opacity="0.35" />
+  <rect x="52" y="56" width="216" height="128" rx="24" fill="url(#pattern-bamboo)" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Noto Sans JP', sans-serif" font-size="30" fill="#713f12">
+    京竹工芸
+  </text>
+</svg>

--- a/public/craft_images/kanoko.svg
+++ b/public/craft_images/kanoko.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="240" viewBox="0 0 320 240">
+  <defs>
+    <radialGradient id="grad-kanoko" cx="50%" cy="45%" r="70%">
+      <stop offset="0%" stop-color="#fff7ed" />
+      <stop offset="100%" stop-color="#fb923c" />
+    </radialGradient>
+    <pattern id="pattern-kanoko" width="28" height="28" patternUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="28" height="28" fill="none" />
+      <circle cx="14" cy="14" r="6" fill="#f97316" fill-opacity="0.45" />
+      <circle cx="4" cy="4" r="4" fill="#ea580c" fill-opacity="0.35" />
+      <circle cx="24" cy="24" r="4" fill="#ea580c" fill-opacity="0.35" />
+    </pattern>
+  </defs>
+  <rect width="320" height="240" fill="url(#grad-kanoko)" />
+  <rect x="36" y="36" width="248" height="168" rx="20" fill="white" fill-opacity="0.35" />
+  <rect x="48" y="48" width="224" height="144" rx="16" fill="url(#pattern-kanoko)" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Noto Sans JP', sans-serif" font-size="30" fill="#9a3412">
+    京鹿の子絞
+  </text>
+</svg>

--- a/public/craft_images/nishijin.svg
+++ b/public/craft_images/nishijin.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="240" viewBox="0 0 320 240">
+  <defs>
+    <linearGradient id="grad-nishijin" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fdf2f8" />
+      <stop offset="100%" stop-color="#c084fc" />
+    </linearGradient>
+    <pattern id="pattern-weave" width="20" height="20" patternUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="20" height="20" fill="#ede9fe" />
+      <path d="M0 10h20M10 0v20" stroke="#a855f7" stroke-width="2" stroke-opacity="0.4" />
+    </pattern>
+  </defs>
+  <rect width="320" height="240" fill="url(#grad-nishijin)" />
+  <rect x="32" y="32" width="256" height="176" rx="16" fill="url(#pattern-weave)" opacity="0.9" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Noto Sans JP', sans-serif" font-size="32" fill="#581c87">
+    西陣織
+  </text>
+</svg>

--- a/public/craft_images/yuzen.svg
+++ b/public/craft_images/yuzen.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="240" viewBox="0 0 320 240">
+  <defs>
+    <linearGradient id="grad-yuzen" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#cffafe" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+    <pattern id="pattern-yuzen" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#0ea5e9" stroke-width="1.5" stroke-opacity="0.4" />
+      <path d="M12 0v24" stroke="#0284c7" stroke-width="1.5" stroke-opacity="0.25" />
+      <circle cx="6" cy="6" r="3" fill="#f472b6" fill-opacity="0.5" />
+      <circle cx="18" cy="18" r="3" fill="#f472b6" fill-opacity="0.5" />
+    </pattern>
+  </defs>
+  <rect width="320" height="240" fill="url(#grad-yuzen)" />
+  <g transform="translate(36 42)">
+    <rect width="248" height="156" rx="24" fill="white" fill-opacity="0.4" />
+    <rect x="12" y="12" width="224" height="132" rx="20" fill="url(#pattern-yuzen)" />
+  </g>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Noto Sans JP', sans-serif" font-size="30" fill="#0c4a6e">
+    京友禅
+  </text>
+</svg>

--- a/public/craft_images/zoen.svg
+++ b/public/craft_images/zoen.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="240" viewBox="0 0 320 240">
+  <defs>
+    <linearGradient id="grad-zoen" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#bbf7d0" />
+      <stop offset="100%" stop-color="#22c55e" />
+    </linearGradient>
+    <pattern id="pattern-zoen" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M0 16c8-10 24-10 32 0" fill="none" stroke="#166534" stroke-width="2" stroke-opacity="0.4" />
+      <circle cx="16" cy="20" r="4" fill="#16a34a" fill-opacity="0.45" />
+    </pattern>
+  </defs>
+  <rect width="320" height="240" fill="url(#grad-zoen)" />
+  <rect x="40" y="48" width="240" height="144" rx="32" fill="white" fill-opacity="0.3" />
+  <rect x="56" y="64" width="208" height="112" rx="26" fill="url(#pattern-zoen)" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Noto Sans JP', sans-serif" font-size="30" fill="#065f46">
+    造園
+  </text>
+</svg>

--- a/types/craft.ts
+++ b/types/craft.ts
@@ -51,13 +51,16 @@ export interface CraftItem {
 export function getPublicUrl(path: string) {
   const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   if (!baseUrl || baseUrl === "undefined" || baseUrl === "null") {
+    if (!path) {
+      return "/placeholder.svg";
+    }
     if (path.startsWith("http://") || path.startsWith("https://")) {
       return path;
     }
     if (path.startsWith("/")) {
       return path;
     }
-    return "/placeholder.svg";
+    return `/${path.replace(/^\/+/u, "")}`;
   }
   return `${baseUrl}/storage/v1/object/public/${path}`;
 }
@@ -89,7 +92,7 @@ export const EXAMPLE_NISHIJIN: CraftItem = {
   },
   details: { path: 'craft_texts/nishijin.md', format: 'md' },
   images: [
-    { path: 'craft_images/nishijin.png' }
+    { path: 'craft_images/nishijin.svg' }
   ]
 };
 
@@ -140,7 +143,7 @@ export const SEED: CraftItem[] = [
       en: 'Nishijin weaving is characterized by intricate patterns using pre-dyed threads...',
       zh: '西阵织物的特点是使用预染线创造复杂的图案...'
     },
-    images: [{ path: 'craft_images/nishijin.png' }]
+    images: [{ path: 'craft_images/nishijin.svg' }]
   },
   {
     id: 102,
@@ -157,7 +160,7 @@ export const SEED: CraftItem[] = [
       en: 'This technique creates complex patterns by binding sections of fabric...',
       zh: '通过不同的捆扎方式创造复杂的图案...'
     },
-    images: [{ path: 'craft_images/kanoko.png' }]
+    images: [{ path: 'craft_images/kanoko.svg' }]
   },
   {
     id: 103,
@@ -174,7 +177,7 @@ export const SEED: CraftItem[] = [
       en: 'Kyoto Yuzen was established in the Edo period...',
       zh: '京友禅起源于江户时代，以丰富的彩绘著称...'
     },
-    images: [{ path: 'craft_images/yuzen.png' }]
+    images: [{ path: 'craft_images/yuzen.svg' }]
   },
   {
     id: 104,
@@ -191,7 +194,7 @@ export const SEED: CraftItem[] = [
       en: 'Japanese gardens include various styles such as dry landscapes...',
       zh: '日本庭园包括枯山水、池泉庭园等多种形式...'
     },
-    images: [{ path: 'craft_images/zoen.png' }]
+    images: [{ path: 'craft_images/zoen.svg' }]
   },
   {
     id: 105,
@@ -208,7 +211,7 @@ export const SEED: CraftItem[] = [
       en: 'Used for tea utensils, flower baskets, and more...',
       zh: '广泛用于茶具、花器等...'
     },
-    images: [{ path: 'craft_images/bamboo.png' }]
+    images: [{ path: 'craft_images/bamboo.svg' }]
   }
 ];
 


### PR DESCRIPTION
## Summary
- add local SVG illustrations for each craft and reference them in the seed data
- improve public URL fallback logic to surface local craft assets when Supabase is not configured

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe20d0734832baa60533670fab8d0