### PR TITLE
Load craft, demo, and event content from Supabase

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -8,10 +8,10 @@ import EventModal from "@/components/modals/EventModal";
 import DemoModal from "@/components/modals/DemoModal";
 import ChatbotModal from "@/components/modals/ChatbotModal";
 import CraftGrid from "@/components/CraftGrid";
-import { DEMO_TEMPLATES } from "@/data/demo.seed";
-import { EVENTS } from "@/data/events.seed";
 import { supabase, type CalendarData } from "@/lib/supabase";
 import type { DemoTemplate, Event } from "@/types/types";
+import { getPublicUrl } from "@/lib/supabasePublic";
+import { mapDemoTemplateRow, mapEventRow, type DemoTemplateRow, type EventRow } from "@/lib/supabaseMappers";
 
 export default function HomePage() {
   const [eventOpen, setEventOpen] = useState(false);
@@ -40,23 +40,37 @@ export default function HomePage() {
         if (error) {
           setTodayDemo(null);
         } else if (calendarRow) {
-          const demo = DEMO_TEMPLATES.find(
-            t => t.id === calendarRow.template_id
-          );
-          setTodayDemo(demo || null);
+          const { data: demoRow, error: demoError } = await supabase
+            .from("demo_templates")
+            .select("*")
+            .eq("id", calendarRow.template_id)
+            .maybeSingle();
+
+          if (demoError || !demoRow) {
+            setTodayDemo(null);
+          } else {
+            setTodayDemo(mapDemoTemplateRow(demoRow as DemoTemplateRow));
+          }
         } else {
           setTodayDemo(null);
         }
 
         // イベントデータの取得（開催期間中のもの）
-        const currentEvents = EVENTS.filter(event => {
-          const start = new Date(event.startDate);
-          const end = new Date(event.endDate);
-          return today >= start && today <= end;
-        });
-        setTodayEvents(currentEvents);
+        const { data: eventsData, error: eventsError } = await supabase
+          .from("events")
+          .select("*")
+          .lte("start_date", todayStr)
+          .gte("end_date", todayStr)
+          .order("start_date", { ascending: true });
+
+        if (eventsError || !eventsData) {
+          setTodayEvents([]);
+        } else {
+          setTodayEvents((eventsData as EventRow[]).map(mapEventRow));
+        }
         setCurrentEventIndex(0);
       } catch (error) {
+        console.error("Failed to load home page data", error);
         setTodayDemo(null);
         setTodayEvents([]);
       } finally {
@@ -92,6 +106,7 @@ export default function HomePage() {
                   fill
                   className="object-cover"
                   sizes="(min-width: 768px) 320px, 100vw"
+                  unoptimized={(todayDemo.img || "").includes("supabase.co")}
                 />
               </div>
               <div className="text-base font-semibold text-neutral-700 mb-2">
@@ -122,11 +137,12 @@ export default function HomePage() {
             <>
               <div className="relative w-full h-96 rounded-lg overflow-hidden">
                 <Image
-                  src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/event_images/${todayEvents[currentEventIndex].id}.png`}
+                  src={getPublicUrl(`event_images/${todayEvents[currentEventIndex].id}.png`)}
                   alt={todayEvents[currentEventIndex].name}
                   fill
                   className="object-cover bg-white"
                   sizes="(min-width: 768px) 320px, 100vw"
+                  unoptimized
                 />
                 {todayEvents.length > 1 && (
                   <>

--- a/components/CraftGrid.tsx
+++ b/components/CraftGrid.tsx
@@ -2,49 +2,96 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import type { CraftItem, Lang } from "@/types/types";
-import { SEED } from "@/data/crafts.seed";
 import { pickLang } from "@/types/types";
 import { getPublicUrl } from "@/lib/supabasePublic";
+import { supabase } from "@/lib/supabase";
+import { mapCraftRow, type CraftRow } from "@/lib/supabaseMappers";
 
 type Props = { lang?: Lang };
 
 export default function CraftGrid({ lang = "ja" }: Props) {
   const router = useRouter();
-  const items = (SEED as CraftItem[]).map((craft) => ({
-    name: String(pickLang(craft.name, lang)),
-    reading: craft.kana ?? "",
-    id: craft.id,
-    imageUrl: getPublicUrl("craft_images/" + craft.id+".png")
-  }));
+  const [crafts, setCrafts] = useState<CraftItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    const fetchCrafts = async () => {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from("crafts")
+        .select("*")
+        .order("id", { ascending: true });
+
+      if (!active) return;
+
+      if (error) {
+        console.error("Failed to fetch crafts from Supabase", error);
+        setCrafts([]);
+      } else {
+        const mapped = (data as CraftRow[] | null)?.map(mapCraftRow) ?? [];
+        setCrafts(mapped);
+      }
+      setLoading(false);
+    };
+
+    fetchCrafts();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const items = useMemo(() => {
+    return crafts.map((craft) => {
+      const label = pickLang(craft.name, lang) ?? "";
+      return {
+        name: label,
+        reading: craft.kana ?? "",
+        id: craft.id,
+        imageUrl: getPublicUrl(`craft_images/${craft.id}.png`)
+      };
+    });
+  }, [crafts, lang]);
 
   return (
     <div>
       <h3 className="font-semibold mb-3">工芸一覧</h3>
-      <div className="grid grid-cols-3 gap-3">
-        {items.map((item) => (
-          <button
-            key={item.id}
-            onClick={() => router.push(`/crafts/${item.id}`)}
-            className="bg-neutral-50 border border-neutral-200 rounded-lg p-2.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:ring-offset-2 transition-colors"
-          >
-            <div className="relative w-full aspect-[4/3] mb-2 rounded overflow-hidden bg-gray-100">
-              <Image
-                src={item.imageUrl}
-                alt={item.name}
-                fill
-                className="object-cover"
-                sizes="(max-width: 768px) 100px, 150px"
-                unoptimized={item.imageUrl.includes('supabase.co')}
-              />
-            </div>
-            <div className="text-center">
-              <div className="font-semibold text-sm">{item.name}</div>
-              {item.reading ? <div className="text-xs text-neutral-600">{item.reading}</div> : null}
-            </div>
-          </button>
-        ))}
-      </div>
+      {loading ? (
+        <div className="grid grid-cols-3 gap-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="animate-pulse bg-neutral-100 border border-neutral-200 rounded-lg p-2.5 h-32" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-3">
+          {items.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => router.push(`/crafts/${item.id}`)}
+              className="bg-neutral-50 border border-neutral-200 rounded-lg p-2.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:ring-offset-2 transition-colors"
+            >
+              <div className="relative w-full aspect-[4/3] mb-2 rounded overflow-hidden bg-gray-100">
+                <Image
+                  src={item.imageUrl}
+                  alt={item.name}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100px, 150px"
+                  unoptimized={item.imageUrl.includes("supabase.co")}
+                />
+              </div>
+              <div className="text-center">
+                <div className="font-semibold text-sm">{item.name}</div>
+                {item.reading ? <div className="text-xs text-neutral-600">{item.reading}</div> : null}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/modals/DemoModal.tsx
+++ b/components/modals/DemoModal.tsx
@@ -39,6 +39,7 @@ export default function DemoModal({
                   fill
                   className="object-cover"
                   sizes="(min-width: 768px) 400px, 100vw"
+                  unoptimized={demo.img.includes("supabase.co")}
                 />
               </div>
               <div>

--- a/components/modals/EventModal.tsx
+++ b/components/modals/EventModal.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import type { Event } from "@/types/types";
+import { getPublicUrl } from "@/lib/supabasePublic";
 
 export default function EventModal({ open, onClose, event }: { open: boolean; onClose: () => void; event: Event }) {
   if (!open) return null;
@@ -32,11 +33,12 @@ export default function EventModal({ open, onClose, event }: { open: boolean; on
         <CardContent className="p-4 space-y-3">
           <div className="relative w-full h-96 rounded-lg overflow-hidden">
             <Image
-              src={`${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/event_images/${event.id}.png`}
+              src={getPublicUrl(`event_images/${event.id}.png`)}
               alt={event.name}
               fill
               className="object-cover bg-white"
               sizes="(min-width: 768px) 400px, 100vw"
+              unoptimized
             />
           </div>
           <div>

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect, ReactNode } from "react";
-import type { UserProfile, AgeGroup, UserLanguage } from "@/types/types";
+import type { UserProfile } from "@/types/types";
 
 interface UserContextType {
   userProfile: UserProfile | null;

--- a/lib/supabaseMappers.ts
+++ b/lib/supabaseMappers.ts
@@ -1,0 +1,100 @@
+import type { CraftItem, DemoTemplate, Event, Multilang } from "@/types/types";
+import { getPublicUrl } from "@/lib/supabasePublic";
+
+export type CraftRow = {
+  id: number;
+  slug: string;
+  name_ja: string | null;
+  name_en: string | null;
+  name_zh: string | null;
+  kana: string | null;
+  summary_ja: string | null;
+  summary_en: string | null;
+  summary_zh: string | null;
+  description_ja: string | null;
+  description_en: string | null;
+  description_zh: string | null;
+  youtube_id: string | null;
+  shop_collection: string | null;
+  details_path: string | null;
+  details_format: string | null;
+};
+
+type MultilangSource = {
+  ja?: string | null;
+  en?: string | null;
+  zh?: string | null;
+};
+
+function toMultilang(source: MultilangSource): Multilang {
+  const result: Multilang = {};
+
+  if (source.ja) result.ja = source.ja;
+  if (source.en) result.en = source.en;
+  if (source.zh) result.zh = source.zh;
+
+  return result;
+}
+
+export function mapCraftRow(row: CraftRow): CraftItem {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: toMultilang({ ja: row.name_ja ?? undefined, en: row.name_en ?? undefined, zh: row.name_zh ?? undefined }),
+    kana: row.kana ?? undefined,
+    summary: toMultilang({ ja: row.summary_ja ?? undefined, en: row.summary_en ?? undefined, zh: row.summary_zh ?? undefined }),
+    description: toMultilang({ ja: row.description_ja ?? undefined, en: row.description_en ?? undefined, zh: row.description_zh ?? undefined }),
+    details: row.details_path
+      ? {
+          path: row.details_path,
+          format: row.details_format === "md" || row.details_format === "txt" || row.details_format === "html" || row.details_format === "json"
+            ? row.details_format
+            : undefined
+        }
+      : undefined,
+    youtubeId: row.youtube_id ?? undefined,
+    shopCollection: row.shop_collection ?? undefined,
+  };
+}
+
+export type DemoTemplateRow = {
+  id: number;
+  name_ja: string | null;
+  name_en: string | null;
+  name_zh: string | null;
+  img: string | null;
+  description_ja: string | null;
+  description_en: string | null;
+  description_zh: string | null;
+};
+
+export function mapDemoTemplateRow(row: DemoTemplateRow): DemoTemplate {
+  return {
+    id: row.id,
+    name: row.name_ja ?? row.name_en ?? row.name_zh ?? "",
+    img: row.img ? getPublicUrl(row.img) : "/images/candle-making-demo.png",
+    description: row.description_ja ?? row.description_en ?? row.description_zh ?? "",
+  };
+}
+
+export type EventRow = {
+  id: number;
+  name_ja: string | null;
+  name_en: string | null;
+  name_zh: string | null;
+  start_date: string;
+  end_date: string;
+  detail_ja: string | null;
+  detail_en: string | null;
+  detail_zh: string | null;
+};
+
+export function mapEventRow(row: EventRow): Event {
+  return {
+    id: row.id,
+    name: row.name_ja ?? row.name_en ?? row.name_zh ?? "",
+    startDate: new Date(row.start_date),
+    endDate: new Date(row.end_date),
+    detail: row.detail_ja ?? row.detail_en ?? row.detail_zh ?? "",
+  };
+}


### PR DESCRIPTION
## Summary
- fetch craft listings and detail data from the Supabase `crafts` table
- load daily demo template and current events from Supabase instead of local seed files
- add shared mappers for Supabase rows and update modal image handling and lint warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e34b9faf3c832b9125db884775bdf2